### PR TITLE
Remove timezone selection and related dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "dependencies": {
         "date-fns": "^4.1.0",
-        "date-fns-tz": "^3.2.0",
         "react": "^19.1.1",
         "react-big-calendar": "^1.19.4",
         "react-dom": "^19.1.1",
@@ -2209,15 +2208,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/date-fns-tz": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
-      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/dayjs": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "date-fns": "^4.1.0",
-    "date-fns-tz": "^3.2.0",
     "react": "^19.1.1",
     "react-big-calendar": "^1.19.4",
     "react-dom": "^19.1.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,10 +7,7 @@ import CalendarView from "./components/CalendarView";
 import EmployeeList from "./components/EmployeeList";
 import Reports from "./components/Reports";
 import { employees } from "./data/employees";
-import { format, isAfter, isBefore, isEqual, parseISO } from "date-fns";
-import * as tz from "date-fns-tz";
-
-const { utcToZonedTime } = tz;
+import { isAfter, isBefore, isEqual } from "date-fns";
 
 
 export default function App() {
@@ -22,9 +19,6 @@ export default function App() {
     end: "",
   });
   const [editingId, setEditingId] = useState(null);
-  const [timeZone, setTimeZone] = useState(
-    Intl.DateTimeFormat().resolvedOptions().timeZone
-  );
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState({ name: null, start: null, end: null });
   const [currentDate, setCurrentDate] = useState(new Date());
@@ -142,25 +136,6 @@ export default function App() {
     <div className="min-h-screen flex flex-col bg-gray-100">
       <Header onSidebarToggle={() => setSidebarOpen(true)} />
       <div className="flex flex-1">
-        <div className="mb-4">
-          <label className="block text-sm font-medium text-gray-600">
-            Time Zone
-          </label>
-          <select
-            className="w-full border p-2 rounded"
-            value={timeZone}
-            onChange={(e) => setTimeZone(e.target.value)}
-          >
-            <option value="America/New_York">America/New_York</option>
-            <option value="America/Chicago">America/Chicago</option>
-            <option value="America/Los_Angeles">America/Los_Angeles</option>
-            <option value="Europe/London">Europe/London</option>
-            <option value="Europe/Berlin">Europe/Berlin</option>
-            <option value="Asia/Tokyo">Asia/Tokyo</option>
-            <option value="UTC">UTC</option>
-          </select>
-        </div>
-
         <Sidebar
           currentPage={currentPage}
           setCurrentPage={setCurrentPage}
@@ -198,7 +173,6 @@ export default function App() {
                   setCurrentDate={setCurrentDate}
                   currentView={currentView}
                   setCurrentView={setCurrentView}
-                  timeZone={timeZone}
                 />
               </div>
             </div>

--- a/src/components/BookingTable.jsx
+++ b/src/components/BookingTable.jsx
@@ -1,9 +1,4 @@
-import { parseISO } from "date-fns";
-import utcToZonedTime from "date-fns-tz/utcToZonedTime";
-
-// ...rest of your imports
-
-const { utcToZonedTime } = tz;
+import { format, parseISO } from "date-fns";
 
 export default function BookingTable({
   records,
@@ -13,7 +8,6 @@ export default function BookingTable({
   setSort,
   startEdit,
   deleteRecord,
-  timeZone,
 }) {
   const toggleSort = (column) => {
     setSort((prev) => {
@@ -72,13 +66,8 @@ export default function BookingTable({
         </thead>
         <tbody>
           {records.map((r) => {
-            // ✅ do calculations here, not inline in JSX
-            const zonedStart = r.start
-              ? utcToZonedTime(parseISO(r.start), timeZone)
-              : null;
-            const zonedEnd = r.end
-              ? utcToZonedTime(parseISO(r.end), timeZone)
-              : null;
+            const startDate = r.start ? parseISO(r.start) : null;
+            const endDate = r.end ? parseISO(r.end) : null;
 
             return (
               <tr
@@ -96,14 +85,10 @@ export default function BookingTable({
                   </span>
                 </td>
                 <td className="border p-2 text-center">
-                  {zonedStart
-                    ? format(zonedStart, "MMM d, yyyy", { timeZone })
-                    : "-"}
+                  {startDate ? format(startDate, "MMM d, yyyy") : "-"}
                 </td>
                 <td className="border p-2 text-center">
-                  {zonedEnd
-                    ? format(zonedEnd, "MMM d, yyyy", { timeZone })
-                    : "-"}
+                  {endDate ? format(endDate, "MMM d, yyyy") : "-"}
                 </td>
                 <td className="border p-2 text-center space-x-2">
                   <button

--- a/src/components/CalendarView.jsx
+++ b/src/components/CalendarView.jsx
@@ -1,9 +1,6 @@
 import { Calendar, dateFnsLocalizer } from "react-big-calendar";
 import { format, parse as dateFnsParse, startOfWeek, getDay } from "date-fns";
 import { parseISO } from "date-fns";
-import * as tz from "date-fns-tz";
-
-const { utcToZonedTime } = tz;
 import enUS from "date-fns/locale/en-US";
 import "react-big-calendar/lib/css/react-big-calendar.css";
 
@@ -27,21 +24,17 @@ export default function CalendarView({
   setCurrentDate,
   currentView,
   setCurrentView,
-  timeZone, 
 }) {
-  const events = records.map((r) => {
-    
-    const start = utcToZonedTime(parseISO(r.start), timeZone);
-    const end = utcToZonedTime(parseISO(r.end), timeZone);
-    return {
+  const events = records
+    .filter((r) => r.start && r.end)
+    .map((r) => ({
       id: r.id,
       title: `${r.name} - ${r.type} ${r.type === "Vacation" ? "🌴" : "✈️"}`,
-      start,
-      end,
+      start: parseISO(r.start),
+      end: parseISO(r.end),
       allDay: false,
       type: r.type,
-    };
-  });
+    }));
 
   return (
     <div className="bg-white p-6 rounded-2xl shadow">


### PR DESCRIPTION
## Summary
- remove the time zone selector and state from the dashboard
- simplify the calendar and booking table to use plain ISO dates without conversions
- drop the date-fns-tz dependency from the project

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd90638a748330a7bc8d83f28335db