### PR TITLE
Add dark mode toggle and theming improvements

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,12 @@ import { isAfter, isBefore, isEqual } from "date-fns";
 
 export default function App() {
   const [records, setRecords] = useState([]);
+  const [darkMode, setDarkMode] = useState(() => {
+    if (typeof window === "undefined") return false;
+    const stored = localStorage.getItem("theme");
+    if (stored) return stored === "dark";
+    return window.matchMedia?.("(prefers-color-scheme: dark)")?.matches ?? false;
+  });
   const [form, setForm] = useState({
     name: employees[0],
     type: "Vacation",
@@ -25,6 +31,17 @@ export default function App() {
   const [currentView, setCurrentView] = useState("month");
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [currentPage, setCurrentPage] = useState("dashboard");
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (darkMode) {
+      root.classList.add("dark");
+      localStorage.setItem("theme", "dark");
+    } else {
+      root.classList.remove("dark");
+      localStorage.setItem("theme", "light");
+    }
+  }, [darkMode]);
 
   // localStorage sync
   useEffect(() => {
@@ -133,8 +150,12 @@ export default function App() {
   }, [records, search, sort]);
 
   return (
-    <div className="min-h-screen flex flex-col bg-gray-100">
-      <Header onSidebarToggle={() => setSidebarOpen(true)} />
+    <div className="min-h-screen flex flex-col bg-gray-100 text-gray-900 transition-colors duration-300 dark:bg-gray-900 dark:text-gray-100">
+      <Header
+        onSidebarToggle={() => setSidebarOpen(true)}
+        darkMode={darkMode}
+        onToggleDarkMode={() => setDarkMode((prev) => !prev)}
+      />
       <div className="flex flex-1">
         <Sidebar
           currentPage={currentPage}
@@ -142,7 +163,7 @@ export default function App() {
           sidebarOpen={sidebarOpen}
           setSidebarOpen={setSidebarOpen}
         />
-        <main className="flex-1 p-6 md:ml-0">
+        <main className="flex-1 p-6 md:ml-0 transition-colors duration-300">
           {currentPage === "dashboard" && (
             <div className="grid grid-cols-1 md:grid-cols-5 gap-6">
               <div className="md:col-span-2 space-y-6">

--- a/src/components/BookingForm.jsx
+++ b/src/components/BookingForm.jsx
@@ -11,9 +11,9 @@ export default function BookingForm({
   records,
 }) {
   return (
-    <div className="bg-white p-6 rounded-2xl shadow space-y-4">
+    <div className="bg-white p-6 rounded-2xl shadow space-y-4 transition-colors duration-300 dark:bg-gray-800 dark:shadow-black/20">
       <div className="flex items-center justify-between">
-        <h2 className="text-xl font-semibold text-gray-700">
+        <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-200">
           {editingId ? "Edit Booking" : "Add Booking"}
         </h2>
         {editingId && (
@@ -29,11 +29,11 @@ export default function BookingForm({
 
       {/* Employee */}
       <div>
-        <label className="block text-sm font-medium text-gray-600">
+        <label className="block text-sm font-medium text-gray-600 dark:text-gray-300">
           Employee
         </label>
         <select
-          className="w-full border p-2 rounded"
+          className="w-full border p-2 rounded bg-white text-gray-900 transition-colors dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
           value={form.name}
           onChange={(e) => setForm({ ...form, name: e.target.value })}
         >
@@ -45,9 +45,9 @@ export default function BookingForm({
 
       {/* Type */}
       <div>
-        <label className="block text-sm font-medium text-gray-600">Type</label>
+        <label className="block text-sm font-medium text-gray-600 dark:text-gray-300">Type</label>
         <select
-          className="w-full border p-2 rounded"
+          className="w-full border p-2 rounded bg-white text-gray-900 transition-colors dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
           value={form.type}
           onChange={(e) => setForm({ ...form, type: e.target.value })}
         >
@@ -59,21 +59,21 @@ export default function BookingForm({
       {/* Dates */}
       <div className="flex gap-2">
         <div className="flex-1">
-          <label className="block text-sm font-medium text-gray-600">
+          <label className="block text-sm font-medium text-gray-600 dark:text-gray-300">
             Start
           </label>
           <input
             type="date"
-            className="w-full border p-2 rounded"
+            className="w-full border p-2 rounded bg-white text-gray-900 transition-colors dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
             value={form.start}
             onChange={(e) => setForm({ ...form, start: e.target.value })}
           />
         </div>
         <div className="flex-1">
-          <label className="block text-sm font-medium text-gray-600">End</label>
+          <label className="block text-sm font-medium text-gray-600 dark:text-gray-300">End</label>
           <input
             type="date"
-            className="w-full border p-2 rounded"
+            className="w-full border p-2 rounded bg-white text-gray-900 transition-colors dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
             value={form.end}
             onChange={(e) => setForm({ ...form, end: e.target.value })}
           />

--- a/src/components/BookingTable.jsx
+++ b/src/components/BookingTable.jsx
@@ -21,42 +21,33 @@ export default function BookingTable({
   };
 
   return (
-    <div className="bg-white p-6 rounded-2xl shadow">
+    <div className="bg-white p-6 rounded-2xl shadow transition-colors duration-300 dark:bg-gray-800 dark:shadow-black/20">
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-xl font-semibold text-gray-700">Schedule</h2>
+        <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-200">Schedule</h2>
         <input
           type="text"
           placeholder="Search by name or type..."
-          className="border rounded px-2 py-1 text-sm w-48"
+          className="border rounded px-2 py-1 text-sm w-48 bg-white text-gray-900 transition-colors dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
         />
       </div>
 
-      <table className="w-full border-collapse rounded-lg overflow-hidden text-sm">
-        <thead className="bg-gray-100 text-gray-700 select-none">
+      <table className="w-full border-collapse rounded-lg overflow-hidden text-sm text-left">
+        <thead className="bg-gray-100 text-gray-700 select-none dark:bg-gray-700 dark:text-gray-200">
           <tr>
-            <th
-              className="p-2 text-left cursor-pointer"
-              onClick={() => toggleSort("name")}
-            >
+            <th className="p-2 cursor-pointer" onClick={() => toggleSort("name")}>
               Name
               {sort.name === "asc" && " ▲"}
               {sort.name === "desc" && " ▼"}
             </th>
             <th className="p-2 text-center">Type</th>
-            <th
-              className="p-2 text-center cursor-pointer"
-              onClick={() => toggleSort("start")}
-            >
+            <th className="p-2 text-center cursor-pointer" onClick={() => toggleSort("start")}> 
               Start
               {sort.start === "asc" && " ▲"}
               {sort.start === "desc" && " ▼"}
             </th>
-            <th
-              className="p-2 text-center cursor-pointer"
-              onClick={() => toggleSort("end")}
-            >
+            <th className="p-2 text-center cursor-pointer" onClick={() => toggleSort("end")}>
               End
               {sort.end === "asc" && " ▲"}
               {sort.end === "desc" && " ▼"}
@@ -72,10 +63,12 @@ export default function BookingTable({
             return (
               <tr
                 key={r.id}
-                className="odd:bg-white even:bg-gray-50 hover:bg-gray-100"
+                className="odd:bg-white even:bg-gray-50 hover:bg-gray-100 dark:odd:bg-gray-800 dark:even:bg-gray-700 dark:hover:bg-gray-600"
               >
-                <td className="border p-2">{r.name}</td>
-                <td className="border p-2 text-center">
+                <td className="border border-gray-100 p-2 dark:border-gray-600">
+                  <span className="text-gray-800 dark:text-gray-100">{r.name}</span>
+                </td>
+                <td className="border border-gray-100 p-2 text-center dark:border-gray-600">
                   <span
                     className={`px-2 py-1 rounded text-white text-xs font-medium ${
                       r.type === "Vacation" ? "bg-green-500" : "bg-blue-500"
@@ -84,13 +77,13 @@ export default function BookingTable({
                     {r.type === "Vacation" ? "🌴 Vacation" : "✈️ Travel"}
                   </span>
                 </td>
-                <td className="border p-2 text-center">
+                <td className="border border-gray-100 p-2 text-center text-gray-700 dark:border-gray-600 dark:text-gray-100">
                   {startDate ? format(startDate, "MMM d, yyyy") : "-"}
                 </td>
-                <td className="border p-2 text-center">
+                <td className="border border-gray-100 p-2 text-center text-gray-700 dark:border-gray-600 dark:text-gray-100">
                   {endDate ? format(endDate, "MMM d, yyyy") : "-"}
                 </td>
-                <td className="border p-2 text-center space-x-2">
+                <td className="border border-gray-100 p-2 text-center space-x-2 dark:border-gray-600">
                   <button
                     onClick={() => startEdit(r)}
                     className="bg-yellow-400 hover:bg-yellow-500 text-white px-2 py-1 rounded text-xs"
@@ -110,7 +103,7 @@ export default function BookingTable({
 
           {records.length === 0 && (
             <tr>
-              <td colSpan="5" className="text-center text-gray-500 p-4">
+              <td colSpan="5" className="text-center text-gray-500 p-4 dark:text-gray-300">
                 No matching records
               </td>
             </tr>

--- a/src/components/CalendarView.jsx
+++ b/src/components/CalendarView.jsx
@@ -37,8 +37,8 @@ export default function CalendarView({
     }));
 
   return (
-    <div className="bg-white p-6 rounded-2xl shadow">
-      <h2 className="text-xl font-semibold mb-4 text-gray-700 flex items-center gap-2">
+    <div className="bg-white p-6 rounded-2xl shadow transition-colors duration-300 dark:bg-gray-800 dark:shadow-black/20">
+      <h2 className="text-xl font-semibold mb-4 text-gray-700 flex items-center gap-2 dark:text-gray-200">
         📅 Calendar View
       </h2>
       <Calendar
@@ -53,6 +53,7 @@ export default function CalendarView({
         onView={(view) => setCurrentView(view)}
         views={["month", "week", "day", "agenda"]}
         defaultView="month"
+        className="rounded-xl border border-gray-200 bg-white text-gray-900 transition-colors dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
         eventPropGetter={(event) => ({
           style: {
             backgroundColor: event.type === "Vacation" ? "#22c55e" : "#3b82f6",

--- a/src/components/EmployeeList.jsx
+++ b/src/components/EmployeeList.jsx
@@ -9,14 +9,14 @@ export default function EmployeeList({
   deleteRecord,
 }) {
   return (
-    <div className="bg-white p-6 rounded-2xl shadow">
-      <h2 className="text-xl font-semibold text-gray-700 mb-4">Employees</h2>
+    <div className="bg-white p-6 rounded-2xl shadow transition-colors duration-300 dark:bg-gray-800 dark:shadow-black/20">
+      <h2 className="text-xl font-semibold text-gray-700 mb-4 dark:text-gray-200">Employees</h2>
 
       {/* Search bar */}
       <input
         type="text"
         placeholder="Search employees..."
-        className="border rounded px-3 py-2 mb-4 w-full md:w-1/2"
+        className="border rounded px-3 py-2 mb-4 w-full md:w-1/2 bg-white text-gray-900 transition-colors dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
         value={search}
         onChange={(e) => setSearch(e.target.value)}
       />
@@ -30,11 +30,11 @@ export default function EmployeeList({
             return (
               <li
                 key={emp}
-                className="border rounded-lg p-4 bg-gray-50 hover:bg-gray-100 transition"
+                className="border rounded-lg p-4 bg-gray-50 hover:bg-gray-100 transition dark:border-gray-600 dark:bg-gray-700 dark:hover:bg-gray-600"
               >
                 <div className="flex items-center justify-between">
-                  <span className="font-medium text-gray-800">{emp}</span>
-                  <span className="text-sm text-gray-500">
+                  <span className="font-medium text-gray-800 dark:text-gray-100">{emp}</span>
+                  <span className="text-sm text-gray-500 dark:text-gray-300">
                     {empBookings.length} booking
                     {empBookings.length !== 1 && "s"}
                   </span>
@@ -42,11 +42,11 @@ export default function EmployeeList({
 
                 {/* Show bookings if any */}
                 {empBookings.length > 0 && (
-                  <ul className="mt-2 space-y-1 text-sm text-gray-700">
+                  <ul className="mt-2 space-y-1 text-sm text-gray-700 dark:text-gray-200">
                     {empBookings.map((b) => (
                       <li
                         key={b.id}
-                        className="flex items-center justify-between border-b last:border-0 py-1"
+                        className="flex items-center justify-between border-b last:border-0 py-1 border-gray-200 dark:border-gray-600"
                       >
                         <span>
                           {b.type === "Vacation" ? "🌴 Vacation" : "✈️ Travel"}{" "}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,24 +1,37 @@
-export default function Header({ onSidebarToggle }) {
+export default function Header({ onSidebarToggle, darkMode, onToggleDarkMode }) {
   return (
-    <header className="bg-white shadow px-6 py-4 flex items-center justify-between">
+    <header className="bg-white shadow px-6 py-4 flex items-center justify-between transition-colors duration-300 dark:bg-gray-800 dark:shadow-black/20">
       <div className="flex items-center gap-4">
         <button
-          className="md:hidden p-2 rounded hover:bg-gray-100"
+          className="md:hidden p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
           onClick={onSidebarToggle}
         >
           <div className="space-y-1">
-            <div className="w-6 h-0.5 bg-gray-600"></div>
-            <div className="w-6 h-0.5 bg-gray-600"></div>
-            <div className="w-6 h-0.5 bg-gray-600"></div>
+            <div className="w-6 h-0.5 bg-gray-600 dark:bg-gray-300"></div>
+            <div className="w-6 h-0.5 bg-gray-600 dark:bg-gray-300"></div>
+            <div className="w-6 h-0.5 bg-gray-600 dark:bg-gray-300"></div>
           </div>
         </button>
-        <h1 className="text-2xl font-bold" style={{ color: "#660666" }}>
+        <h1 className="text-2xl font-bold text-purple-800 dark:text-purple-200">
           Marcela&apos;s Employee Manager
         </h1>
       </div>
       <div className="flex items-center gap-4">
-        <button className="text-sm text-gray-600 hover:text-gray-800">
-          Settings
+        <button
+          type="button"
+          onClick={onToggleDarkMode}
+          className="flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors duration-200 hover:text-gray-900 dark:text-gray-200 dark:hover:text-white"
+          aria-pressed={darkMode}
+        >
+          <span className={`relative inline-flex h-5 w-10 items-center rounded-full transition-colors ${darkMode ? "bg-purple-500" : "bg-gray-300"}`}>
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${darkMode ? "translate-x-5" : "translate-x-1"}`}
+            />
+          </span>
+          <span className="hidden sm:inline">{darkMode ? "Dark" : "Light"} Mode</span>
+          <span aria-hidden className="sm:hidden">
+            {darkMode ? "🌙" : "☀️"}
+          </span>
         </button>
         <div className="w-8 h-8 rounded-full bg-purple-600 text-white flex items-center justify-center">
           M

--- a/src/components/Reports.jsx
+++ b/src/components/Reports.jsx
@@ -44,12 +44,12 @@ export default function Reports({ records }) {
   }, [records]);
 
   return (
-    <div className="bg-white p-6 rounded-2xl shadow space-y-8">
-      <h2 className="text-2xl font-semibold text-gray-700 mb-6">Reports 📊</h2>
+    <div className="bg-white p-6 rounded-2xl shadow space-y-8 transition-colors duration-300 dark:bg-gray-800 dark:shadow-black/20">
+      <h2 className="text-2xl font-semibold text-gray-700 mb-6 dark:text-gray-200">Reports 📊</h2>
 
       {/* Bookings per Employee */}
       <div>
-        <h3 className="text-lg font-medium text-gray-700 mb-3">
+        <h3 className="text-lg font-medium text-gray-700 mb-3 dark:text-gray-200">
           Bookings per Employee
         </h3>
         <BarChart width={800} height={300} data={bookingsPerEmployee}>
@@ -64,7 +64,7 @@ export default function Reports({ records }) {
 
       {/* Vacation vs Travel */}
       <div>
-        <h3 className="text-lg font-medium text-gray-700 mb-3">
+        <h3 className="text-lg font-medium text-gray-700 mb-3 dark:text-gray-200">
           Vacation vs Travel
         </h3>
         <PieChart width={400} height={300}>
@@ -91,7 +91,7 @@ export default function Reports({ records }) {
 
       {/* Monthly Distribution */}
       <div>
-        <h3 className="text-lg font-medium text-gray-700 mb-3">
+        <h3 className="text-lg font-medium text-gray-700 mb-3 dark:text-gray-200">
           Monthly Distribution of Bookings
         </h3>
         <LineChart width={800} height={300} data={monthlyDistribution}>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -13,14 +13,14 @@ export default function Sidebar({
         />
       )}
       <aside
-        className={`fixed inset-y-0 left-0 transform bg-white shadow p-6 w-64 transition-transform duration-200 z-40 md:static md:translate-x-0 ${
+        className={`fixed inset-y-0 left-0 transform bg-white shadow p-6 w-64 transition-transform duration-200 z-40 transition-colors dark:bg-gray-900 dark:text-gray-100 dark:shadow-black/20 md:static md:translate-x-0 ${
           sidebarOpen ? "translate-x-0" : "-translate-x-full"
         }`}
       >
         <div className="flex justify-between items-center mb-6 md:hidden">
-          <h2 className="text-lg font-semibold text-gray-700">Menu</h2>
+          <h2 className="text-lg font-semibold text-gray-700 dark:text-gray-200">Menu</h2>
           <button
-            className="p-2 rounded hover:bg-gray-100"
+            className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
             onClick={() => setSidebarOpen(false)}
           >
             ✕
@@ -33,8 +33,8 @@ export default function Sidebar({
               onClick={() => setCurrentPage(page)}
               className={`w-full text-left px-3 py-2 rounded font-medium ${
                 currentPage === page
-                  ? "bg-purple-100 text-purple-700"
-                  : "hover:bg-gray-100"
+                  ? "bg-purple-100 text-purple-700 dark:bg-purple-500/20 dark:text-purple-200"
+                  : "hover:bg-gray-100 dark:hover:bg-gray-800"
               }`}
             >
               {page.charAt(0).toUpperCase() + page.slice(1)}

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,7 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -17,54 +12,99 @@
 @tailwind components;
 @tailwind utilities;
 
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #f3f4f6;
+  color: #111827;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+html.dark body {
+  background: #111827;
+  color: #f9fafb;
+}
 
 a {
   font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+  color: #4f46e5;
+  text-decoration: none;
 }
+
 a:hover {
-  color: #535bf2;
+  color: #4338ca;
 }
 
-body {
-  margin: 0;
-  background: #f3f4f6;
+/* React Big Calendar dark theme adjustments */
+.dark .rbc-calendar {
+  background-color: #111827;
+  color: #f9fafb;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+.dark .rbc-toolbar button {
+  color: #e5e7eb;
+  border-color: #4b5563;
+  background-color: #1f2937;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+.dark .rbc-toolbar button:hover,
+.dark .rbc-toolbar button:focus {
+  background-color: #4338ca;
+  border-color: #4338ca;
+  color: #f9fafb;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+.dark .rbc-toolbar .rbc-active {
+  background-color: #4c1d95;
+  border-color: #4c1d95;
+  color: #f9fafb;
+}
+
+.dark .rbc-month-view,
+.dark .rbc-time-view,
+.dark .rbc-agenda-view {
+  background-color: transparent;
+}
+
+.dark .rbc-header,
+.dark .rbc-time-header,
+.dark .rbc-agenda-table {
+  background-color: #1f2937;
+  color: #e5e7eb;
+  border-color: #374151;
+}
+
+.dark .rbc-day-bg,
+.dark .rbc-time-content,
+.dark .rbc-timeslot-group,
+.dark .rbc-time-slot,
+.dark .rbc-agenda-date-cell,
+.dark .rbc-agenda-time-cell,
+.dark .rbc-agenda-event-cell {
+  border-color: #374151;
+}
+
+.dark .rbc-off-range-bg {
+  background-color: #0f172a;
+}
+
+.dark .rbc-today {
+  background-color: rgba(99, 102, 241, 0.25);
+}
+
+/* Recharts dark theme tweaks */
+.dark .recharts-default-tooltip {
+  background-color: #1f2937 !important;
+  border: 1px solid #4b5563 !important;
+  color: #f9fafb !important;
+}
+
+.dark .recharts-legend-item-text {
+  color: #e5e7eb !important;
+}
+
+.dark .recharts-cartesian-axis-tick-value tspan,
+.dark .recharts-label tspan,
+.dark .recharts-text tspan {
+  fill: #e5e7eb !important;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: "class",
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- replace the header settings button with a dark mode toggle that stores user preference
- update the app layout and key components with coordinated dark theme styles
- enable class-based dark mode in Tailwind and add global overrides for the calendar and charts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd9bdf12dc8330b63ea59f406313b7